### PR TITLE
Use file compression and the correct separator

### DIFF
--- a/cartoframes/context.py
+++ b/cartoframes/context.py
@@ -460,15 +460,15 @@ class CartoContext(object):
             """removes temporary file"""
             os.remove(filepath)
 
-        tempfile = '{temp_dir}/{table_name}.csv'.format(temp_dir=temp_dir,
-                                                        table_name=table_name)
+        tempfile = os.path.join('temp_dir, table_name + '.csv.gz')
         self._debug_print(tempfile=tempfile)
         df.drop(labels=[geom_col], axis=1, errors='ignore').to_csv(
                 path_or_buf=tempfile,
                 na_rep='',
                 header=pgcolnames,
                 index=False,
-                encoding='utf-8')
+                encoding='utf-8',
+                compression='gzip')
 
         with open(tempfile, 'rb') as f:
             params = {'type_guessing': False}


### PR DESCRIPTION
Pandas can write, and Cardo can upload, CSVs faster if the files are compressed.
Also, the os.path.join is a more reliable way to join paths.